### PR TITLE
Change to use "Poison" in the BRAND_AMMO effect to find the …

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -4990,7 +4990,7 @@ bool effect_handler_BRAND_AMMO(effect_handler_context_t *context)
 	bool used = false;
 
 	/* Select the brand */
-	const char *brand = one_in_(3) ? "Flame" : (one_in_(2) ? "Frost" : "Venom");
+	const char *brand = one_in_(3) ? "Flame" : (one_in_(2) ? "Frost" : "Poison");
 
 	context->ident = true;
 


### PR DESCRIPTION
… appropriate brand.  Avoids this crash, http://angband.oook.cz/forum/showpost.php?p=147607&postcount=130 , reported by wobbly.