### PR TITLE
fix wide array of bugs with Single Combat

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -1535,7 +1535,7 @@ bool effect_handler_RECALL(effect_handler_context_t *context)
 				}
 
 				/* Check for replacement */
-				if (point < num_recall_points + 1) {
+				if ((point < num_recall_points + 1) && (place)) {
 					player->recall[point] = place;
 				}
 

--- a/src/effects.c
+++ b/src/effects.c
@@ -1491,6 +1491,7 @@ bool effect_handler_RECALL(effect_handler_context_t *context)
 
 	/* No recall */
 	if ((OPT(player, birth_no_recall) && !player->total_winner) ||
+		((!current) && (cave->mon_cnt == 1)) ||
 		((player->place == player->home) && !player->recall_pt)) {
 		msg("Nothing happens.");
 		return true;
@@ -3430,8 +3431,8 @@ bool effect_handler_DESTRUCTION(effect_handler_context_t *context)
 
 	context->ident = true;
 
-	/* No effect in town */
-	if (!player->depth) {
+	/* No effect in town or arena */
+	if ((!player->depth) || (player->upkeep->arena_level)) {
 		msg("The ground shakes for a moment.");
 		return true;
 	}
@@ -3547,10 +3548,10 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 
 	context->ident = true;
 
-	if (player->depth) {
+	if ((player->depth) && (!player->upkeep->arena_level)) {
 		msg("The ground shakes! The ceiling caves in!");
 	} else {
-		/* No effect in town */
+		/* No effect in town or arena */
 		msg("The ground shakes for a moment.");
 		return true;
 	}
@@ -5488,7 +5489,8 @@ bool effect_handler_SINGLE_COMBAT(effect_handler_context_t *context)
 		}
 
 		/* Swap the targeted monster with the first in the monster list */
-		if (cave_monster(cave, 1)->race) {
+		if (old_idx == 1) { /* Do nothing */ }
+		else if (cave_monster(cave, 1)->race) {
 			monster_index_move(old_idx, cave_monster_max(cave));
 			monster_index_move(1, old_idx);
 			monster_index_move(cave_monster_max(cave), 1);

--- a/src/effects.c
+++ b/src/effects.c
@@ -3548,7 +3548,7 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 
 	context->ident = true;
 
-	if ((player->depth) && (!player->upkeep->arena_level)) {
+	if ((player->depth) && ((!player->upkeep->arena_level) || (context->origin.what == SRC_MONSTER))) {
 		msg("The ground shakes! The ceiling caves in!");
 	} else {
 		/* No effect in town or arena */

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -761,9 +761,10 @@ void process_world(struct chunk *c)
 
 			/* Determine the level */
 			if (player->place != player->home) {
+				int new_last_place = (player->upkeep->arena_level) ? player->last_place : 0;
 				msgt(MSG_TPLEVEL, "You feel yourself yanked homewards!");
 				player_change_place(player, player->home);
-				player->last_place = 0;
+				player->last_place = new_last_place;
 			} else {
 				msgt(MSG_TPLEVEL, "You feel yourself yanked away!");
 				player_change_place(player, player->recall_pt);

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -1144,7 +1144,7 @@ void run_game_loop(void)
 			/* Kill arena monster */
 			if (arena) {
 				player->upkeep->arena_level = false;
-				kill_arena_monster(player->upkeep->health_who);
+				if (player->upkeep->health_who) kill_arena_monster(player->upkeep->health_who);
 			}
 		}
 

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -3133,6 +3133,7 @@ struct chunk *arena_gen(struct player *p, int min_height, int min_width) {
 	square_set_mon(c, mon->grid, mon->midx);
 	c->mon_max = mon->midx + 1;
 	c->mon_cnt = 1;
+	mon->target.midx = -1; /* Careful... */
 	update_mon(mon, c, true);
 	player->upkeep->health_who = mon;
 
@@ -3144,3 +3145,4 @@ struct chunk *arena_gen(struct player *p, int min_height, int min_width) {
 
 	return c;
 }
+	

--- a/src/generate.c
+++ b/src/generate.c
@@ -1413,15 +1413,19 @@ void prepare_next_level(struct chunk **c, struct player *p)
 				cave_store(*c, prev_name, false, true);
 				cave_store(p->cave, prev_name, true, true);
 			}
-			else if (!player->place)
+			else if (!p->place)
 			/* Paranoia - try to catch unusual exits from Arena
 			 * Ideally unusual exits never happen and this code is unnecessary */
 			{
-				player->upkeep->arena_level = false;
-				if (!player->last_place) player->last_place = player->home; /* paranoia */
-				player_change_place(player, player->last_place);
-				player->upkeep->arena_level = true;				
-				player->upkeep->health_who = NULL; /* Suppress "defeated" message for unusual exit */
+				p->upkeep->arena_level = false;
+				if (!p->last_place) 
+				{
+					p->last_place = p->home; /* paranoia */
+					persist = OPT(p, birth_levels_persist);
+				}
+				player_change_place(p, p->last_place);
+				p->upkeep->arena_level = true;				
+				p->upkeep->health_who = NULL; /* Suppress "defeated" message for unusual exit */
 				my_strcpy(prev_name, level_name(&world->levels[p->last_place]),
 				  sizeof(prev_name));
 				my_strcpy(new_name, level_name(&world->levels[p->place]), sizeof(new_name));

--- a/src/generate.c
+++ b/src/generate.c
@@ -1413,6 +1413,19 @@ void prepare_next_level(struct chunk **c, struct player *p)
 				cave_store(*c, prev_name, false, true);
 				cave_store(p->cave, prev_name, true, true);
 			}
+			else if (!player->place)
+			/* Paranoia - try to catch unusual exits from Arena
+			 * Ideally unusual exits never happen and this code is unnecessary */
+			{
+				player->upkeep->arena_level = false;
+				if (!player->last_place) player->last_place = player->home; /* paranoia */
+				player_change_place(player, player->last_place);
+				player->upkeep->arena_level = true;				
+				player->upkeep->health_who = NULL; /* Suppress "defeated" message for unusual exit */
+				my_strcpy(prev_name, level_name(&world->levels[p->last_place]),
+				  sizeof(prev_name));
+				my_strcpy(new_name, level_name(&world->levels[p->place]), sizeof(new_name));
+			}
 		} else {
 			/* Save the town */
 			if (!((*c)->depth) && !chunk_find_name(prev_name)) {
@@ -1432,7 +1445,7 @@ void prepare_next_level(struct chunk **c, struct player *p)
 		/* Persistent levels need careful work */
 		struct chunk *old_level = chunk_find_name(new_name);
 
-		/* Check all the possibilites */
+		/* Check all the possibilities */
 		if (old_level && (old_level != cave)) {
 			/* We found an old level, load the known level and assign */
 			int i;
@@ -1504,12 +1517,13 @@ void prepare_next_level(struct chunk **c, struct player *p)
 	}
 
 	/* Know the town */
-	if (!(p->depth)) {
+	if ((!(p->depth)) || (!(p->place))) {
 		cave_known(p);
 	}
 
 	/* Apply illumination */
-	cave_illuminate(*c, is_daytime());
+	if (p->place) cave_illuminate(*c, is_daytime());
+	else wiz_light(*c, p, true);
 
 	/* The dungeon is ready */
 	character_dungeon = true;

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -1034,6 +1034,9 @@ static bool monster_turn_multiply(struct chunk *c, struct monster *mon)
 
 	/* Too many breeders on the level already */
 	if (c->num_repro >= z_info->repro_monster_max) return false;
+	
+	/* No breeding in single combat */
+	if (player->upkeep->arena_level) return false;	
 
 	/* Count the adjacent monsters */
 	for (y = mon->grid.y - 1; y <= mon->grid.y + 1; y++)

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -1309,6 +1309,11 @@ bool mon_take_hit(struct monster *mon, int dam, bool *fear, const char *note)
 		/* Deal with arena monsters */
 		if (player->upkeep->arena_level) {
 			player->upkeep->generate_level = true;
+			player->upkeep->arena_level = false;
+			if (!player->last_place) player->last_place = player->home; /* paranoia */
+			player_change_place(player, player->last_place);
+			player->upkeep->arena_level = true;
+			player->upkeep->health_who = mon;
 			(*fear) = false;
 			return true;
 		}


### PR DESCRIPTION
* handle place changes properly, fixing bug with player getting stuck in arena
* fix crash if player saves and exits during Single Combat
* fix crash if target monster cannot be tracked properly
* fix bug with enemy visibility
* fix bugs with arena illumination
* fix crash if player leaves the Arena in an unexpected way
* disallow multiplying in Arena
* tweak availability of Recall, Destruction and Earthquake during single combat, thus preventing weirdness