### PR TITLE
Reset the contents of home at birth

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -492,14 +492,14 @@ void store_reset(void) {
 
 		/* Initial stock setup for stores */
 		while (s) {
+			s->stock_num = 0;
+			object_pile_free(s->stock);
+			s->stock = NULL;
 			if (store_is_home(s)) {
 				s = s->next;
 				continue;
 			}
-			s->stock_num = 0;
 			store_shuffle(s);
-			object_pile_free(s->stock);
-			s->stock = NULL;
 			for (j = 0; j < 10; j++)
 				store_maint(s);
 			s = s->next;


### PR DESCRIPTION
Prevents stuff from a dead character carrying over when starting from the save file for a dead character as reported at http://angband.oook.cz/forum/showpost.php?p=147811&postcount=12 and http://angband.oook.cz/forum/showpost.php?p=147719&postcount=155 .