### PR TITLE
Fixes for the failed src/tests/game tests in the CI environment

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          ./configure --with-no-install
+          env CFLAGS=-DPRIVATE_USER_PATH=\\\"./lib/user\\\" ./configure --with-no-install
           make
           make tests
 

--- a/src/obj-design.c
+++ b/src/obj-design.c
@@ -3889,6 +3889,9 @@ void initialize_random_artifacts(u32b randart_seed)
 	/* Open the file, write a header */
 	path_build(fname, sizeof(fname), ANGBAND_DIR_USER, "randart.txt");
 	randart_file = file_open(fname, MODE_WRITE, FTYPE_TEXT);
+	if (!randart_file) {
+		quit_fmt("Error - can't create %s.", fname);
+	}
 	file_putf(randart_file,
 			  "# Artifact file for random artifacts with seed %08x\n\n\n",
 			  randart_seed);

--- a/src/tests/game/basic.c
+++ b/src/tests/game/basic.c
@@ -59,6 +59,8 @@ int setup_tests(void **state) {
 	/* Init the game */
 	set_file_paths();
 	init_angband();
+	/* Necessary for creating the randart file. */
+	create_needed_dirs();
 
 	return 0;
 }

--- a/src/tests/game/mage.c
+++ b/src/tests/game/mage.c
@@ -36,6 +36,8 @@ int setup_tests(void **state) {
 	/* Init the game */
 	set_file_paths();
 	init_angband();
+	/* Necessary for creating the randart file. */
+	create_needed_dirs();
 
 	return 0;
 }


### PR DESCRIPTION
- Cleanly exit (rather than segfault) if the randart file could not be opened for writing.
- Use create_needed_dirs() in the setup for the tests in src/tests/game so creating the randart file will work even if FAangband hasn't been run previously.
- Override PRIVATE_USER_PATH when building the tests in the CI environment since ~/.angband/FAangband does not seem to to be writable there.