### PR TITLE
Change name of Window resource file since it is tied to PROGNAME

### DIFF
--- a/src/Makefile.src
+++ b/src/Makefile.src
@@ -71,7 +71,7 @@ SNDSDLFILES = snd-sdl.o
 TESTMAINFILES = main-test.o
 
 WINMAINFILES = \
-        win/angband.res \
+        win/$(PROGNAME).res \
         main-win.o \
         win/readdib.o \
         win/readpng.o \


### PR DESCRIPTION
Fixes mingw cross-compiler builds for Windows that are set up using the configure script.