### PR TITLE
Adapt inven_wield() test setup to FAangband

### DIFF
--- a/src/tests/player/inven-wield.c
+++ b/src/tests/player/inven-wield.c
@@ -188,6 +188,8 @@ int setup_tests(void **state) {
 	/* Set up the player. */
 	cmdq_push(CMD_BIRTH_INIT);
 	cmdq_push(CMD_BIRTH_RESET);
+	cmdq_push(CMD_CHOOSE_MAP);
+	cmd_set_arg_choice(cmdq_peek(), "choice", 3);
 	cmdq_push(CMD_CHOOSE_RACE);
 	cmd_set_arg_choice(cmdq_peek(), "choice", 0);
 	cmdq_push(CMD_CHOOSE_CLASS);

--- a/src/tests/player/inven-wield.c
+++ b/src/tests/player/inven-wield.c
@@ -185,6 +185,8 @@ static bool check_similar(const struct object* obj1, const struct object *obj2) 
 int setup_tests(void **state) {
 	set_file_paths();
 	init_angband();
+	/* Necessary for creating the randart file. */
+	create_needed_dirs();
 
 	/* Set up the player. */
 	cmdq_push(CMD_BIRTH_INIT);

--- a/src/tests/player/inven-wield.c
+++ b/src/tests/player/inven-wield.c
@@ -7,6 +7,7 @@
 #include "cmd-core.h"
 #include "effects.h"
 #include "game-world.h"
+#include "generate.h"
 #include "init.h"
 #include "obj-curse.h"
 #include "obj-gear.h"


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/FirstAgeAngband/issues/156 and a macOS compilation error with Xcode 12.  Adds some paranoia with respect to the randart file.