### PR TITLE
For the combined values (ui-entry-renderers.c), use safe_queue_chars() …

### DIFF
--- a/src/ui-entry-renderers.c
+++ b/src/ui-entry-renderers.c
@@ -789,7 +789,7 @@ static void renderer_COMPACT_PERCENTAGE_RESIST_RENDERER_WITH_COMBINED_AUX(
 				p.y += 1;
 			}
 		} else {
-			Term_queue_chars(details->label_position.x,
+			safe_queue_chars(details->label_position.x,
 				details->label_position.y, nlabel,
 				info->label_colors[effect_index], label);
 		}
@@ -824,7 +824,7 @@ static void renderer_PERCENTAGE_RESIST_COMBINED_RENDERER(
 	if (color < 2) {
 		return;
 	}
-	Term_queue_chars(details->value_position.x,
+	safe_queue_chars(details->value_position.x,
 					 details->value_position.y,
 					 4, //ui_entry_renderer_query_value_width(n),
 					 info->colors[color], w_percent);
@@ -1188,7 +1188,7 @@ static void renderer_MODIFIER_COMBINED_RENDERER(
 	} else if (val < 0) {
 		color = 2;
 	}
-	Term_queue_chars(details->value_position.x + 1,
+	safe_queue_chars(details->value_position.x + 1,
 					 details->value_position.y,
 					 strlen(total), //ui_entry_renderer_query_value_width(n),
 					 info->colors[color], w_total);


### PR DESCRIPTION
in more places to avoid crashes if the terminal is too small for the full display.  Should resolve Arralen's bug report here, http://angband.oook.cz/forum/showpost.php?p=153484&postcount=322 (well, at least the parts about the crashes when turning on player(extra) for a terminal that's too small; I don't know what's being referred to in the second part about "STATUS").