### PR TITLE
Avoid cosmetic warnings when using Makefile.osx

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -3394,7 +3394,7 @@ static bool effect_handler_TELEPORT_LEVEL(effect_handler_context_t *context)
 
 	/* Now actually do the level change */
 	if (up) {
-		char *msg = (current->topography == TOP_CAVE) ?
+		const char *msg = (current->topography == TOP_CAVE) ?
 			"You rise up through the ceiling." : "You rise into the air.";
 		msgt(MSG_TPLEVEL, msg);
 		target_place = player_get_next_place(player->place, "up", 1);

--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -2061,7 +2061,7 @@ static enum parser_error parse_ghost_spells_off(struct parser *p) {
 	return ret;
 }
 
-struct parser *init_parse_ghost(void) {
+static struct parser *init_parse_ghost(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
 

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -1726,13 +1726,13 @@ static void monster_turn(struct chunk *c, struct monster *mon)
 			   && square_isview(c, mon->grid) && (c->ghost->string_type == 1)
 			   && !c->ghost->has_spoken && one_in_(3)) {
 		/* Player ghosts may have a unique message they can say. */
-		char m_name[80];
+		char ghost_name[80];
 
 		/* Acquire the monster name/poss.  The player ghost will 
 		 * always be identified, to heighten the effect.*/
-		monster_desc(m_name, sizeof(m_name), mon, MDESC_SHOW);
+		monster_desc(ghost_name, sizeof(ghost_name), mon, MDESC_SHOW);
 
-		msg("%s says: '%s'", m_name, c->ghost->string);
+		msg("%s says: '%s'", ghost_name, c->ghost->string);
 		c->ghost->has_spoken = true;
 	}
 


### PR DESCRIPTION
The last commit may need to be changed if the intent was for the fully revealed name of the player ghost to be used in other messages about the ghost's movement rather than only being applied to its speech.