### PR TITLE
Add "chart:" line to avoid histories like "You are the only child of a Hobbit Bum.  Warrior.  …."

### DIFF
--- a/lib/gamedata/history.txt
+++ b/lib/gamedata/history.txt
@@ -132,6 +132,7 @@ phrase:You are one of several children of a Hobbit
 chart:10:11:100
 phrase:You are the only child of a Hobbit 
 
+chart:11:3:5
 phrase:Bum.  
 chart:11:3:30
 phrase:Tavern Owner.  


### PR DESCRIPTION
An alternate solution would be to delete the "phrase:Bum." line.

I may not have gotten the demographics of hobbit bums correct:  this change has 1 for every 5 tavern owners.