### PR TITLE
Constrain the placement of forest clearings so they can't appear …

### DIFF
--- a/src/gen-wilderness.c
+++ b/src/gen-wilderness.c
@@ -1416,13 +1416,23 @@ struct chunk *forest_gen(struct player *p, int height, int width)
 
 	/* Try fairly hard */
 	for (j = 0; j < 50; j++) {
-		int a, b, x, y;
+		int a, b, x, xlo, xhi, y, ylo, yhi;
 
-		/* Try for a clearing */
+		/*
+		 * Try for a clearing.  Constrain the center choice so the
+		 * bounding box is in bounds and the center won't be within
+		 * the maximum possible extent of the walls created by
+		 * make_edges() (that's to avoid a room that's entirely
+		 * surrounded by those walls).
+		 */
 		a = randint0(6) + 4;
 		b = randint0(5) + 4;
-		y = randint0(c->height - 1) + 1;
-		x = randint0(c->width - 1) + 1;
+		ylo = MAX(b, 7);
+		yhi = MIN(c->height - 1 - b, c->height - 8);
+		y = rand_range(ylo, yhi);
+		xlo = MAX(a, 10);
+		xhi = MIN(c->width - 1 - a, c->height - 11);
+		x = rand_range(xlo, xhi);
 		made_plat = generate_starburst_room(c, y - b, x - a, y + b, x + a,
 											false, FEAT_GRASS, true);
 


### PR DESCRIPTION
…completely surrounded by the permanent walls at the edges.

Does not appear to have any affect on #188 or #144 .  The disconnected areas prevented by this change appear to comparatively rare (about 1 in 5000 forest levels).

There's other sources of disconnected areas on forest levels (and likely elsewhere).  Those appear to be due to the placement of terrain in make_formation().  I'll leave those for another pull request.  Also, since it is at least possible to circumvent those disconnects by digging, maybe they're a feature rather than a bug.