### PR TITLE
Tweak make_formation()

### DIFF
--- a/src/gen-wilderness.c
+++ b/src/gen-wilderness.c
@@ -657,12 +657,17 @@ static int make_formation(struct chunk *c, struct player *p, struct loc grid,
 	/* Make a formation */
 	while (i != (prob - 1)) {
 		/* Avoid paths, stay in bounds */
-		if (((square_feat(c, tgrid)->fidx != base_feat1) &&
-			 (square_feat(c, tgrid)->fidx != base_feat2))
-			|| !square_in_bounds_fully(c, tgrid) || square_ismark(c, tgrid)
-			|| square_isvault(c, tgrid)) {
-			mem_free(all_feat);
-			return (total);
+		if (!square_in_bounds_fully(c, tgrid)
+			|| (square_feat(c, tgrid)->fidx != base_feat1
+				&& square_feat(c, tgrid)->fidx != base_feat2)
+			|| square_ismark(c, tgrid)
+			|| square_isvault(c, tgrid)
+			|| loc_eq(tgrid, p->grid)
+			|| (!feat_is_monster_walkable(all_feat[i])
+				&& square_monster(c, tgrid))
+			|| (!feat_is_object_holding(all_feat[i])
+				&& square_object(c, tgrid))) {
+			break;
 		}
 
 		/* Check for treasure */

--- a/src/gen-wilderness.c
+++ b/src/gen-wilderness.c
@@ -915,8 +915,8 @@ struct chunk *plain_gen(struct player *p, int height, int width)
 	/* Place some formations */
 	while (form_grids < (50 * c->depth + 1000)) {
 		/* Choose a place */
-		grid.y = randint0(c->height - 1) + 1;
-		grid.x = randint0(c->width - 1) + 1;
+		grid.y = randint1(c->height - 2);
+		grid.x = randint1(c->width - 2);
 		form_grids += make_formation(c, p, grid, FEAT_GRASS, FEAT_GRASS,
 									 form_feats, "Plains", c->depth + 1);
 	}
@@ -924,8 +924,8 @@ struct chunk *plain_gen(struct player *p, int height, int width)
 	/* And some water */
 	form_grids = 0;
 	while (form_grids < 300) {
-		grid.y = randint0(c->height - 1) + 1;
-		grid.x = randint0(c->width - 1) + 1;
+		grid.y = randint1(c->height - 2);
+		grid.x = randint1(c->width - 2);
 		form_grids += make_formation(c, p, grid, FEAT_GRASS, FEAT_GRASS, ponds,
 									 "Plains", 10);
 	}
@@ -1110,8 +1110,8 @@ struct chunk *mtn_gen(struct player *p, int height, int width)
 	/* Make a few formations */
 	while (form_grids < 50 * (c->depth)) {
 		/* Choose a place */
-		grid.y = randint0(c->height - 1) + 1;
-		grid.x = randint0(c->width - 1) + 1;
+		grid.y = randint1(c->height - 2);
+		grid.x = randint1(c->width - 2);
 		form_grids += make_formation(c, p, grid, FEAT_GRANITE, FEAT_GRANITE,
 									 form_feats, "Mountain", c->depth * 2);
 		/* Now join it up */
@@ -1453,8 +1453,8 @@ struct chunk *forest_gen(struct player *p, int height, int width)
 	/* Place some formations */
 	while (form_grids < (50 * c->depth + 1000)) {
 		/* Choose a place */
-		grid.y = randint0(c->height - 1) + 1;
-		grid.x = randint0(c->width - 1) + 1;
+		grid.y = randint1(c->height - 2);
+		grid.x = randint1(c->width - 2);
 		form_grids += make_formation(c, p, grid, FEAT_TREE, FEAT_TREE2,
 									 form_feats, "Forest", c->depth + 1);
 	}
@@ -1462,8 +1462,8 @@ struct chunk *forest_gen(struct player *p, int height, int width)
 	/* And some water */
 	form_grids = 0;
 	while (form_grids < 300) {
-		grid.y = randint0(c->height - 1) + 1;
-		grid.x = randint0(c->width - 1) + 1;
+		grid.y = randint1(c->height - 2);
+		grid.x = randint1(c->width - 2);
 		form_grids += make_formation(c, p, grid, FEAT_TREE, FEAT_TREE2, ponds,
 									 "Forest", 10);
 	}
@@ -1533,8 +1533,8 @@ struct chunk *swamp_gen(struct player *p, int height, int width)
 	/* Place some formations (but not many, and less for more danger) */
 	while (form_grids < 20000 / c->depth) {
 		/* Choose a place */
-		grid.y = randint0(c->height - 1) + 1;
-		grid.x = randint0(c->width - 1) + 1;
+		grid.y = randint1(c->height - 2);
+		grid.x = randint1(c->width - 2);
 		form_grids += make_formation(c, p, grid, FEAT_GRASS, FEAT_WATER,
 									 form_feats, "Swamp", c->depth);
 	}


### PR DESCRIPTION
1. Avoid the added terrain embedding a monster in a wall (saw at least one instance of that; likely because monsters in a wilderness vault spilled onto grids that were not marked as belonging to the vault).  Out of paranoia, also avoid modifying the player's grid or embedding an object in something that can't hold objects.
2. For a bit of efficiency, always pass a grid that's not on the edge to make_formation() since it always does nothing with grids on the edge.
3. Add a local test (so overly restrictive) to avoid disconnecting parts of the cave when terrain is added by make_formation().  If you want to get a sense of the difference in texture that causes for the added terrain, the attached swamp-make_formation-standard.html.gz is a West Beleriand 11 map (as compressed HTML) without that change, and the attached swamp-make_formation-changed.html.gz is a West Beleriand 11 map with the change.

[swamp-make_formation-standard.html.gz](https://github.com/NickMcConnell/FirstAgeAngband/files/6792966/swamp-make_formation-standard.html.gz)
[swamp-make_formation-changed.html.gz](https://github.com/NickMcConnell/FirstAgeAngband/files/6792968/swamp-make_formation-changed.html.gz)
