### PR TITLE
Constrain the placement of clearings in deserts and valleys so they …

### DIFF
--- a/src/gen-wilderness.c
+++ b/src/gen-wilderness.c
@@ -1692,13 +1692,23 @@ struct chunk *desert_gen(struct player *p, int height, int width)
 
 	/* Try fairly hard */
 	for (j = 0; j < 50; j++) {
-		int a, b, x, y;
+		int a, b, x, xlo, xhi, y, ylo, yhi;
 
-		/* Try for a clearing */
+		/*
+		 * Try for a clearing.  Constrain the center choice so the
+		 * bounding box is in bounds and the center won't be within
+		 * the maximum possible extent of the walls created by
+		 * make_edges() (that's to avoid a room that's entirely
+		 * surrounded by those walls).
+		 */
 		a = randint0(6) + 4;
 		b = randint0(5) + 4;
-		y = randint0(c->height - 1) + 1;
-		x = randint0(c->width - 1) + 1;
+		ylo = MAX(b, 7);
+		yhi = MIN(c->height - 1 - b, c->height - 8);
+		y = rand_range(ylo, yhi);
+		xlo = MAX(a, 10);
+		xhi = MIN(c->width - 1 - a, c->height - 11);
+		x = rand_range(xlo, xhi);
 		made_plat = generate_starburst_room(c, y - b, x - a, y + b, x + a,
 											false, FEAT_GRASS, false);
 
@@ -1938,14 +1948,23 @@ struct chunk *valley_gen(struct player *p, int height, int width)
 
 	/* Try fairly hard */
 	for (j = 0; j < 50; j++) {
-		int a, b, x, y;
+		int a, b, x, xlo, xhi, y, ylo, yhi;
 
-		/* Try for a clearing */
+		/*
+		 * Try for a clearing.  Constrain the center choice so the
+		 * bounding box is in bounds, the center won't be within the
+		 * the maximum possible extent of the walls created by
+		 * make_edges(), and the clearing won't intrude on the empty
+		 * space created by make_edges().
+		 */
 		a = randint0(6) + 4;
 		b = randint0(5) + 4;
-		y = randint1(c->height - 3);
-		x = randint1(c->width - 2);
-		if (square_feat(c, loc(x, y))->fidx == FEAT_VOID) continue;
+		ylo = MAX(b, 10);
+		yhi = c->height - 11 - b;
+		y = rand_range(ylo, yhi);
+		xlo = MAX(a, 10);
+		xhi = MIN(c->width - 1 - a, c->height - 11);
+		x = rand_range(xlo, xhi);
 		made_plat = generate_starburst_room(c, y - b, x - a, y + b, x + a,
 											false, FEAT_GRASS, true);
 


### PR DESCRIPTION
…can't be entirely closed in the permanent walls.  For valleys, also constrain the position so it can't possibly encroach on empty space grids at the bottom of the map.

That avoids a small number of cases (likely similar to forest maps where it was roughly 1/5000 maps) with completely enclosed clearings.