### PR TITLE
Change path drawing to avoid spawn location problems

### DIFF
--- a/src/gen-wilderness.c
+++ b/src/gen-wilderness.c
@@ -165,33 +165,56 @@ static void river_move(struct chunk *c, int *xp)
 }
 
 /**
- * Places paths to adjacent surface places, and joins them.  Does each 
- * direction separately, which is a bit repetitive -NRM-
+ * Places paths to adjacent surface places, and joins them.
  */
 static void alloc_paths(struct chunk *c, struct player *p, int place,
 						int last_place)
 {
-	int y, x, i, j, num, path;
+	int dir, i, j, num, path, coord;
 	int pcoord = player->upkeep->path_coord;
 	struct loc grid, pgrid, tgrid;
 
 	struct level *lev = &world->levels[place];
 	struct level *last_lev = &world->levels[last_place];
-	struct level *north = NULL;
-	struct level *east = NULL;
-	struct level *south = NULL;
-	struct level *west = NULL;
+	struct {
+		struct level* level;
+		bool vert, river_special;
+		int f_less, f_more;
+		int coord;
+		int para_off_min, para_off_max;
+		int perp_off_min, perp_off_max;
+	} dirs[] = {
+		{ (lev->north) ? level_by_name(world, lev->north) : NULL,
+			false, true,
+			FEAT_LESS_NORTH, FEAT_MORE_NORTH,
+			1,
+			-19, 20,
+			c->height / 3 - 9, c->height / 3 + 10 },
+		{ (lev->east) ? level_by_name(world, lev->east) : NULL,
+			true, false,
+			FEAT_LESS_EAST, FEAT_MORE_EAST,
+			c->width - 2,
+			-19, 20,
+			-(c->height / 3) - 12, -(c->height / 3) + 7 },
+		{ (lev->south) ? level_by_name(world, lev->south) : NULL,
+			false, true,
+			FEAT_LESS_SOUTH, FEAT_MORE_SOUTH,
+			c->height - 2,
+			-19, 20,
+			-(c->height / 3) - 12, -(c->height / 3) + 7 },
+		{ (lev->west) ? level_by_name(world, lev->west) : NULL,
+			true, false,
+			FEAT_LESS_WEST, FEAT_MORE_WEST,
+			1,
+			-19, 20,
+			c->height / 3 - 9, c->height / 3 + 10 },
+	};
 
 	struct loc pathend[20], gp[512];
 	int pspot, num_paths = 0, path_grids = 0;
 
 	bool jumped = true;
 	bool river;
-
-	if (lev->north) north = level_by_name(world, lev->north);
-	if (lev->east) east = level_by_name(world, lev->east);
-	if (lev->south) south = level_by_name(world, lev->south);
-	if (lev->west) west = level_by_name(world, lev->west);
 
 	/* River levels need special treatment */
 	river = (lev->topography == TOP_RIVER);
@@ -201,33 +224,43 @@ static void alloc_paths(struct chunk *c, struct player *p, int place,
 		pathend[i].x = 0;
 	}
 
-	/* Hack for finishing Nan Dungortheb */
-	//if ((last_place == q_list[2].place) && (last_place != 0))
-	//	north = last_place;
+	for (dir = 0; dir < 4; ++dir) {
+		if (!dirs[dir].level) continue;
 
-	/* North */
-	if (north) {
 		/* Harder or easier? */
-		if (north->depth > lev->depth) {
-			path = FEAT_MORE_NORTH;
-		} else {
-			path = FEAT_LESS_NORTH;
-		}
+		path = (dirs[dir].level->depth > lev->depth) ?
+			dirs[dir].f_more : dirs[dir].f_less;
 
 		/* Way back */
-		if ((north == last_lev) && (player->upkeep->create_stair)) {
+		if (dirs[dir].level == last_lev
+				&& player->upkeep->create_stair) {
 			/* No paths in river */
-			if (river)
+			if (river && dirs[dir].river_special)
 				river_move(c, &pcoord);
 
-			pgrid = loc(pcoord, 1);
+			if (dirs[dir].vert) {
+				pgrid = loc(dirs[dir].coord, pcoord);
+				tgrid = loc(
+					dirs[dir].coord + rand_range(
+						dirs[dir].perp_off_min,
+						dirs[dir].perp_off_max),
+					pgrid.y + rand_range(
+						dirs[dir].para_off_min,
+						dirs[dir].para_off_max));
+			} else {
+				pgrid = loc(pcoord, dirs[dir].coord);
+				tgrid = loc(
+					pgrid.x + rand_range(
+						dirs[dir].para_off_min,
+						dirs[dir].para_off_max),
+					dirs[dir].coord + rand_range(
+						dirs[dir].perp_off_min,
+						dirs[dir].perp_off_max));
+			}
 			square_set_feat(c, pgrid, path);
 			square_mark(c, pgrid);
 			jumped = false;
 
-			/* Make path to nowhere */
-			tgrid = loc(pgrid.x + randint1(40) - 20,
-						1 + c->height / 3 + randint1(20) - 10);
 			path_to_nowhere(c, pgrid, tgrid, pathend, &num_paths);
 		}
 
@@ -236,147 +269,40 @@ static void alloc_paths(struct chunk *c, struct player *p, int place,
 
 		/* Place "num" paths */
 		for (i = 0; i < num; i++) {
-			x = 1 + randint0(c->width / num - 2) +
-				i * c->width / num;
+			if (dirs[dir].vert) {
+				coord = 1 + randint0(c->height / num - 2)
+					+ (i * c->height) / num;
+			} else {
+				coord = 1 + randint0(c->width / num - 2)
+					+ (i * c->width) / num;
+			}
 
 			/* No paths in river */
-			if (river)
-				river_move(c, &x);
+			if (river && dirs[dir].river_special)
+				river_move(c, &coord);
 
-			grid = loc(x, 1);
+			if (dirs[dir].vert) {
+				grid = loc(dirs[dir].coord, coord);
+				tgrid = loc(
+					dirs[dir].coord + rand_range(
+						dirs[dir].perp_off_min,
+						dirs[dir].perp_off_max),
+					grid.y + rand_range(
+						dirs[dir].para_off_min,
+						dirs[dir].para_off_max));
+			} else {
+				grid = loc(coord, dirs[dir].coord);
+				tgrid = loc(
+					grid.x + rand_range(
+						dirs[dir].para_off_min,
+						dirs[dir].para_off_max),
+					dirs[dir].coord + rand_range(
+						dirs[dir].perp_off_min,
+						dirs[dir].perp_off_max));
+			}
 			square_set_feat(c, grid, path);
 			square_mark(c, grid);
 
-			/* Make paths to nowhere */
-			tgrid = loc(grid.x + randint1(40) - 20,
-						1 + c->height / 3 + randint1(20) - 10);
-			path_to_nowhere(c, grid, tgrid, pathend, &num_paths);
-		}
-	}
-
-	/* East */
-	if (east) {
-		/* Harder or easier? */
-		if (east->depth > lev->depth) {
-			path = FEAT_MORE_EAST;
-		} else {
-			path = FEAT_LESS_EAST;
-		}
-
-		/* Way back */
-		if ((east == last_lev) && (player->upkeep->create_stair)) {
-			pgrid = loc(c->width - 2, pcoord);
-			square_set_feat(c, pgrid, path);
-			square_mark(c, pgrid);
-			jumped = false;
-
-			/* Make path to nowhere */
-			tgrid = loc(c->width - c->height / 3 - randint1(20) + 8,
-						pgrid.y + randint1(40) - 20);
-			path_to_nowhere(c, pgrid, tgrid, pathend, &num_paths);
-		}
-
-		/* Decide number of paths */
-		num = rand_range(2, 3);
-
-		/* Place "num" paths */
-		for (i = 0; i < num; i++) {
-			y = 1 + randint0(c->height / num - 2) +	i * c->height / num;
-			grid = loc(c->width - 2, y);
-			square_set_feat(c, grid, path);
-			square_mark(c, grid);
-
-			/* Make paths to nowhere */
-			tgrid = loc(c->width - c->height / 3 - randint1(20) + 8,
-						grid.y + randint1(40) - 20);
-			path_to_nowhere(c, grid, tgrid, pathend, &num_paths);
-		}
-	}
-
-	/* South */
-	if (south) {
-		/* Harder or easier? */
-		if (south->depth > lev->depth) {
-			path = FEAT_MORE_SOUTH;
-		} else {
-			path = FEAT_LESS_SOUTH;
-		}
-
-		/* Way back */
-		if ((south == last_lev) && (p->upkeep->create_stair)) {
-			/* No paths in river */
-			if (river)
-				river_move(c, &pcoord);
-
-			pgrid = loc(pcoord, c->height - 2);
-			square_set_feat(c, pgrid, path);
-			square_mark(c, pgrid);
-			jumped = false;
-
-			/* Make path to nowhere */
-			tgrid = loc(pgrid.x + randint1(40) - 20,
-						c->height - c->height / 3 - randint1(20) + 8);
-			path_to_nowhere(c, pgrid, tgrid, pathend, &num_paths);
-		}
-
-		/* Decide number of paths */
-		num = rand_range(2, 3);
-
-		/* Place "num" paths */
-		for (i = 0; i < num; i++) {
-			x = 1 + randint0(c->width / num - 2) +
-				i * c->width / num;
-
-			/* No paths in river */
-			if (river)
-				river_move(c, &x);
-
-			grid = loc(x, c->height - 2);
-			square_set_feat(c, grid, path);
-			square_mark(c, grid);
-
-			/* Make paths to nowhere */
-			tgrid = loc(grid.x + randint1(40) - 20,
-						c->height - c->height / 3 - randint1(20) + 8);
-			path_to_nowhere(c, grid, tgrid, pathend, &num_paths);
-		}
-	}
-
-	/* West */
-	if (west) {
-		/* Harder or easier? */
-		if (west->depth > lev->depth) {
-			path = FEAT_MORE_WEST;
-		} else {
-			path = FEAT_LESS_WEST;
-		}
-
-		/* Way back */
-		if ((west == last_lev) && (p->upkeep->create_stair)) {
-			pgrid = loc(1, pcoord);
-			square_set_feat(c, pgrid, path);
-			square_mark(c, pgrid);
-			jumped = false;
-
-			/* Make path to nowhere */
-			tgrid = loc(1 + c->height / 3 + randint1(20) - 10,
-						pgrid.y + randint1(40) - 20);
-			path_to_nowhere(c, pgrid, tgrid, pathend, &num_paths);
-		}
-
-		/* Decide number of paths */
-		num = rand_range(2, 3);
-
-		/* Place "num" paths */
-		for (i = 0; i < num; i++) {
-			y = 1 + randint0(c->height / num - 2) +	i * c->height / num;
-			grid = loc(1, y);
-			square_set_feat(c, grid, path);
-			square_mark(c, grid);
-
-			/* make paths to nowhere */
-			tgrid = loc(1 + c->height / 3 + randint1(20) - 10,
-						grid.y + randint1(40) - 20);
 			path_to_nowhere(c, grid, tgrid, pathend, &num_paths);
 		}
 	}

--- a/src/gen-wilderness.c
+++ b/src/gen-wilderness.c
@@ -170,7 +170,7 @@ static void river_move(struct chunk *c, int *xp)
 static void alloc_paths(struct chunk *c, struct player *p, int place,
 						int last_place)
 {
-	int dir, i, j, num, path, coord;
+	int dir, i, j, num, path, back, coord;
 	int pcoord = player->upkeep->path_coord;
 	struct loc grid, pgrid, tgrid;
 
@@ -238,6 +238,7 @@ static void alloc_paths(struct chunk *c, struct player *p, int place,
 			if (river && dirs[dir].river_special)
 				river_move(c, &pcoord);
 
+			back = pcoord;
 			if (dirs[dir].vert) {
 				pgrid = loc(dirs[dir].coord, pcoord);
 				tgrid = loc(
@@ -262,6 +263,8 @@ static void alloc_paths(struct chunk *c, struct player *p, int place,
 			jumped = false;
 
 			path_to_nowhere(c, pgrid, tgrid, pathend, &num_paths);
+		} else {
+			back = -2;
 		}
 
 		/* Decide number of paths */
@@ -280,6 +283,9 @@ static void alloc_paths(struct chunk *c, struct player *p, int place,
 			/* No paths in river */
 			if (river && dirs[dir].river_special)
 				river_move(c, &coord);
+
+			/* Skip if too close to the way back. */
+			if (ABS(coord - back) < 3) continue;
 
 			if (dirs[dir].vert) {
 				grid = loc(dirs[dir].coord, coord);


### PR DESCRIPTION
That resolves most of the cases I've seen of https://github.com/NickMcConnell/FirstAgeAngband/issues/214 .

The ones that I've seen that aren't fixed by this are on mountain levels where the drawing of a plateau overwrites the stairs.  One fix for that would be to avoid overwriting marked grids in generate_starburst_room(), but I didn't track down if that would break something when starburst rooms are used for dungeons.  Another option would be to put the generation of the plateaus before alloc_paths() in mtn_gen().

I also haven't tested mountaintop levels at all so there could be spawn location issues on those that haven't been addressed by the changes here.