### PR TITLE
Avoid spawning problems on mountain and mountaintop levels

### DIFF
--- a/src/gen-wilderness.c
+++ b/src/gen-wilderness.c
@@ -1250,8 +1250,10 @@ struct chunk *mtntop_gen(struct player *p, int height, int width)
 
 	/* Summit */
 	square_set_feat(c, top, FEAT_GRANITE);
+	square_mark(c, top);
 	for (i = 0; i < 8; i++) {
 		square_set_feat(c, loc_sum(top, ddgrid[i]), FEAT_GRANITE);
+		square_mark(c, loc_sum(top, ddgrid[i]));
 	}
 
 	/* Count the floors */

--- a/src/gen-wilderness.c
+++ b/src/gen-wilderness.c
@@ -1041,6 +1041,7 @@ struct chunk *mtn_gen(struct player *p, int height, int width)
 			if ((square_feat(c, grid)->fidx == FEAT_ROAD) ||
 				(square_feat(c, grid)->fidx == FEAT_GRASS)) {
 				square_set_feat(c, grid, FEAT_MORE);
+				square_mark(c, grid);
 				i--;
 				stairs[2 - i] = grid;
 				if (!i && (level_topography(last_place) == TOP_CAVE))

--- a/src/gen-wilderness.c
+++ b/src/gen-wilderness.c
@@ -1182,12 +1182,6 @@ struct chunk *mtn_gen(struct player *p, int height, int width)
 	for (grid.y = 0; grid.y < c->height; grid.y++) {
 		for (grid.x = 0; grid.x < c->width; grid.x++) {
 			square_unmark(c, grid);
-
-			/* Paranoia - remake the dungeon walls */
-			if ((grid.y == 0) || (grid.x == 0) ||
-				(grid.y == c->height - 1) || (grid.x == c->width - 1)) {
-				square_set_feat(c, grid, FEAT_PERM);
-			}
 		}
 	}
 	ensure_connectedness(c, false);

--- a/src/gen-wilderness.c
+++ b/src/gen-wilderness.c
@@ -1212,16 +1212,14 @@ struct chunk *mtn_gen(struct player *p, int height, int width)
  */
 struct chunk *mtntop_gen(struct player *p, int height, int width)
 {
-	bool made_plat;
-
 	struct loc grid, top;
 	int i, j, k;
 	int plats, a, b;
 	int spot, floors = 0;
 	bool placed = false;
 
-    /* Make the level */
-    struct chunk *c = cave_new(z_info->dungeon_hgt, z_info->dungeon_wid);
+	/* Make the level */
+	struct chunk *c = cave_new(z_info->dungeon_hgt, z_info->dungeon_wid);
 	c->depth = p->depth;
 
 	/* Start with void */
@@ -1333,39 +1331,40 @@ struct chunk *mtntop_gen(struct player *p, int height, int width)
 		/* Try for a plateau */
 		a = randint0(6) + 4;
 		b = randint0(5) + 4;
-		top.y = randint0(c->height - 1) + 1;
-		top.x = randint0(c->width - 1) + 1;
-		made_plat = generate_starburst_room(c, top.y - b, top.x - a, top.y + b,
-											top.x + a, false, FEAT_ROAD, false);
+		top.y = rand_range(b, c->height - 1 - b);
+		top.x = rand_range(a, c->width - 1 - a);
+		if (!check_clearing_space(c, loc_sum(top, loc(-a, -b)),
+				loc_sum(top, loc(a, b)))
+				|| !generate_starburst_room(c, top.y - b,
+				top.x - a, top.y + b, top.x + a, false,
+				FEAT_ROAD, false)) continue;
 
-		/* Success ? */
-		if (made_plat) {
-			plats--;
+		/* Success */
+		plats--;
 
-			/* Adjust the terrain a bit */
-			for (grid.y = top.y - b; grid.y < top.y + b; grid.y++) {
-				for (grid.x = top.x - a; grid.x < top.x + a; grid.x++) {
-					/* Only change generated stuff */
-					if (square_feat(c, grid)->fidx == FEAT_VOID)
-						continue;
+		/* Adjust the terrain a bit */
+		for (grid.y = top.y - b; grid.y < top.y + b; grid.y++) {
+			for (grid.x = top.x - a; grid.x < top.x + a; grid.x++) {
+				/* Only change generated stuff */
+				if (square_feat(c, grid)->fidx == FEAT_VOID)
+					continue;
 
-					/* Place some rock */
-					if (one_in_(5)) {
-						square_set_feat(c, grid, FEAT_GRANITE);
-						continue;
-					}
+				/* Place some rock */
+				if (one_in_(5)) {
+					square_set_feat(c, grid, FEAT_GRANITE);
+					continue;
+				}
 
-					/* rubble */
-					if (one_in_(8)) {
-						square_set_feat(c, grid, FEAT_PASS_RUBBLE);
-						continue;
-					}
+				/* rubble */
+				if (one_in_(8)) {
+					square_set_feat(c, grid, FEAT_PASS_RUBBLE);
+					continue;
+				}
 
-					/* and the odd tree */
-					if (one_in_(20)) {
-						square_set_feat(c, grid, FEAT_TREE2);
-						continue;
-					}
+				/* and the odd tree */
+				if (one_in_(20)) {
+					square_set_feat(c, grid, FEAT_TREE2);
+					continue;
 				}
 			}
 		}


### PR DESCRIPTION
- Mark some terrain that wasn't previously marked (Amon Rudh entrances; summit for mountaintop).
- Don't allow plateaus to overwrite marked terrain (done by adding a blanket check for possible squares in the plateau before generating the plateau).

A sample of four different Eriador 9 levels before the change is in Eriador9Before.html.gz .  Another 4 maps from Eriador 9 after the change are in Eriador9After.html.gz .

Avoids the remaining issues I've seen with the spawning location on mountain levels ( https://github.com/NickMcConnell/FirstAgeAngband/issues/214 ).

The mountaintop changes mimic the ones for the mountain levels, but haven't been tested.

Also drop the paranoid redrawing of the boundary walls in mountain generation as likely unnecessary.  In any case,  the check in verify_level() will cause levels with broken boundary walls to be regenerated.

[Eriador9Before.html.gz](https://github.com/NickMcConnell/FirstAgeAngband/files/6803326/Eriador9Before.html.gz)
[Eriador9After.html.gz](https://github.com/NickMcConnell/FirstAgeAngband/files/6803328/Eriador9After.html.gz)