### PR TITLE
Change non-projectable terrain lighting when in sunlight

### DIFF
--- a/src/cave-view.c
+++ b/src/cave-view.c
@@ -19,6 +19,7 @@
 #include "angband.h"
 #include "cave.h"
 #include "cmds.h"
+#include "game-world.h"
 #include "init.h"
 #include "monster.h"
 #include "player-calcs.h"
@@ -526,11 +527,12 @@ static bool source_can_light_wall(struct chunk *c, struct player *p,
  * \param c Is the chunk in which to do the evaluation.
  * \param p Is the player to test.
  * \param wgrid Is the location of the wall.
+ * \param sunlit Is true if the level is lit by the sun.
  * \return Return true if the wall will appear to be lit for the player.
  * Otherwise, return false.
  */
 static bool glow_can_light_wall(struct chunk *c, struct player *p,
-		struct loc wgrid)
+		struct loc wgrid, bool sunlit)
 {
 	struct loc pn = next_grid(wgrid, motion_dir(wgrid, p->grid)), chk;
 
@@ -540,10 +542,10 @@ static bool glow_can_light_wall(struct chunk *c, struct player *p,
 	if (loc_eq(pn, wgrid)) return true;
 
 	/*
-	 * If the grid in the direction of the player is not a wall, is in a
-	 * room, and is glowing, it'll illuminate the wall.
+	 * If the grid in the direction of the player is not a wall, is either
+	 * sunlit or in a room, and is glowing, it'll illuminate the wall.
 	 */
-	if (!square_iswall(c, pn) && square_isroom(c, pn) &&
+	if (!square_iswall(c, pn) && (sunlit || square_isroom(c, pn)) &&
 			square_isglow(c, pn)) return true;
 
 	/*
@@ -556,13 +558,15 @@ static bool glow_can_light_wall(struct chunk *c, struct player *p,
 		if (pn.y != wgrid.y) {
 			chk.x = pn.x;
 			chk.y = wgrid.y;
-			if (!square_iswall(c, chk) && square_isroom(c, chk) &&
+			if (!square_iswall(c, chk) &&
+					(sunlit || square_isroom(c, chk)) &&
 					square_isglow(c, chk) &&
 					source_can_light_wall(c, p, chk, wgrid))
 				return true;
 			chk.x = wgrid.x;
 			chk.y = pn.y;
-			if (!square_iswall(c, chk) && square_isroom(c, chk) &&
+			if (!square_iswall(c, chk) &&
+					(sunlit || square_isroom(c, chk)) &&
 					square_isglow(c, chk) &&
 					source_can_light_wall(c, p, chk, wgrid))
 				return true;
@@ -571,14 +575,14 @@ static bool glow_can_light_wall(struct chunk *c, struct player *p,
 			chk.y = wgrid.y - 1;
 			if (square_in_bounds(c, chk) &&
 					!square_iswall(c, chk) &&
-					square_isroom(c, chk) &&
+					(sunlit || square_isroom(c, chk)) &&
 					square_isglow(c, chk) &&
 					source_can_light_wall(c, p, chk, wgrid))
 				return true;
 			chk.y = wgrid.y + 1;
 			if (square_in_bounds(c, chk) &&
 					!square_iswall(c, chk) &&
-					square_isroom(c, chk) &&
+					(sunlit || square_isroom(c, chk)) &&
 					square_isglow(c, chk) &&
 					source_can_light_wall(c, p, chk, wgrid))
 				return true;
@@ -587,13 +591,13 @@ static bool glow_can_light_wall(struct chunk *c, struct player *p,
 		chk.y = pn.y;
 		chk.x = wgrid.x - 1;
 		if (square_in_bounds(c, chk) && !square_iswall(c, chk) &&
-				square_isroom(c, chk) &&
+				(sunlit || square_isroom(c, chk)) &&
 				square_isglow(c, chk) &&
 				source_can_light_wall(c, p, chk, wgrid))
 			return true;
 		chk.x = wgrid.x + 1;
 		if (square_in_bounds(c, chk) && !square_iswall(c, chk) &&
-				square_isroom(c, chk) &&
+				(sunlit || square_isroom(c, chk)) &&
 				square_isglow(c, chk) &&
 				source_can_light_wall(c, p, chk, wgrid))
 			return true;
@@ -660,6 +664,7 @@ static void calc_lighting(struct chunk *c, struct player *p)
 	int dir, k, x, y;
 	int light = p->state.cur_light, radius = ABS(light) - 1;
 	int old_light = square_light(c, p->grid);
+	bool sunlit = is_daytime() && outside();
 
 	/* Starting values based on permanent light */
 	for (y = 0; y < c->height; y++) {
@@ -668,7 +673,7 @@ static void calc_lighting(struct chunk *c, struct player *p)
 
 			if (square_isglow(c, grid) &&
 					(!square_iswall(c, grid) ||
-					glow_can_light_wall(c, p, grid))) {
+					glow_can_light_wall(c, p, grid, sunlit))) {
 				c->squares[y][x].light = 1;
 			} else {
 				c->squares[y][x].light = 0;


### PR DESCRIPTION
Because of the changes in Angband's lighting model, standing in a sunlit clearing wouldn't let the player see the first non-projectable grid at the edge of the clearing.  This change is one way to make it so those grids will be lit and visible.